### PR TITLE
Migrate callbacks to hook API #6

### DIFF
--- a/classes/hook_callbacks.php
+++ b/classes/hook_callbacks.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_categorybanner;
+
+use core\hook\output\before_standard_head_html_generation;
+use core\hook\output\before_standard_top_of_body_html_generation;
+
+/**
+ * Hook callbacks for local_categorybanner.
+ *
+ * @package    local_categorybanner
+ * @author     Benjamin Walker (benjaminwalker@catalyst-au.net)
+ * @copyright  2025 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class hook_callbacks {
+
+    /**
+     * Callback to add head elements.
+     *
+     * @param before_standard_head_html_generation $hook
+     */
+    public static function before_standard_head_html_generation(before_standard_head_html_generation $hook): void {
+        global $CFG;
+
+        if (during_initial_install() || isset($CFG->upgraderunning)) {
+            // Do nothing during installation or upgrade.
+            return;
+        }
+
+        local_categorybanner_before_standard_html_head();
+    }
+
+    /**
+     * Callback to add HTML content to the top of the page body.
+     *
+     * @param before_standard_top_of_body_html_generation $hook
+     */
+    public static function before_standard_top_of_body_html_generation(before_standard_top_of_body_html_generation $hook): void {
+        global $CFG;
+
+        if (during_initial_install() || isset($CFG->upgraderunning)) {
+            // Do nothing during installation or upgrade.
+            return;
+        }
+
+        local_categorybanner_before_standard_top_of_body_html();
+    }
+}

--- a/db/hooks.php
+++ b/db/hooks.php
@@ -15,17 +15,25 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information
+ * Hook callbacks for local_categorybanner
  *
  * @package    local_categorybanner
- * @copyright  2025 Service Ecole Media <sem.web@edu.ge.ch>
+ * @author     Benjamin Walker (benjaminwalker@catalyst-au.net)
+ * @copyright  2025 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025080800;        // The current plugin version
-$plugin->requires  = 2022112800;        // Requires Moodle 4.1 or later
-$plugin->component = 'local_categorybanner';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '2.0.1';
+$callbacks = [
+    [
+        'hook' => \core\hook\output\before_standard_head_html_generation::class,
+        'callback' => '\local_categorybanner\hook_callbacks::before_standard_head_html_generation',
+        'priority' => 0,
+    ],
+    [
+        'hook' => \core\hook\output\before_standard_top_of_body_html_generation::class,
+        'callback' => '\local_categorybanner\hook_callbacks::before_standard_top_of_body_html_generation',
+        'priority' => 0,
+    ],
+];


### PR DESCRIPTION
Hi @Fanny1203 

You can have both legacy callbacks and hooks in the same version of the plugin so these issues can be resolved. 

Right now this PR just calls your legacy functions, which should work fine and resolve these issues, but I would recommend some refactoring to move the code in the legacy callbacks to a standalone class that is called by both the legacy callback and hooks. 

Feel free to modify anything as required.

Closes #2 Closes #6